### PR TITLE
Feature/filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,25 @@ a much more testable interface as it only uses the WP functions if they are avai
 
 ## Methods
 
-Methods are the same methods provided by version 1.0 of the [Événement](https://github.com/igorw/evenement/tree/v1.0.0) library.
+### on
+
+Delegate to WordPress' [add_action](https://codex.wordpress.org/Function_Reference/add_action) function. In test environments a local
+collection of listeners will be used.
+
+### emit
+
+Delegate to WordPress' [do_action](https://codex.wordpress.org/Function_Reference/do_action) function. In test environments a local
+collection of listeners will be used.
+
+### filter
+
+Delegate to WordPress' [add_filter](https://codex.wordpress.org/Function_Reference/add_filter) function. In test environments a local
+collection of listeners will be used.
+
+### applyFilters
+
+Delegate to WordPress' [apply_filters](https://codex.wordpress.org/Function_Reference/apply_filters) function. In test environments a
+local collection of listeners will be used.
 
 ## Tests
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
         }
     ],
     "require": {
-        "evenement/evenement": "~1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/EventEmitter.php
+++ b/src/EventEmitter.php
@@ -2,7 +2,7 @@
 
 namespace NetRivet\WordPress;
 
-class EventEmitter
+class EventEmitter implements EventEmitterInterface
 {
     /**
      * @var array
@@ -10,7 +10,7 @@ class EventEmitter
     protected $listeners = array();
 
     /**
-     * Register a function with a hook. TODO support $accepted_args
+     * {@inheritdoc}
      *
      * @param $hook
      * @param $function_to_add
@@ -34,7 +34,7 @@ class EventEmitter
     }
 
     /**
-     * Register a filter with a hook. TODO support $accepted args
+     * {@inheritdoc}
      *
      * @param $hook
      * @param $function_to_add
@@ -56,7 +56,7 @@ class EventEmitter
     }
 
     /**
-     * This function invokes all functions for a hook and transforms the given value(s)
+     * {@inheritdoc}
      *
      * @param $hook
      * @param $value
@@ -77,7 +77,7 @@ class EventEmitter
 
 
     /**
-     * This function invokes all functions attached to action hook $tag
+     * {@inheritdoc}
      *
      * @param $tag
      */

--- a/src/EventEmitter.php
+++ b/src/EventEmitter.php
@@ -2,10 +2,12 @@
 
 namespace NetRivet\WordPress;
 
-use Evenement\EventEmitter as CoreEmitter;
-
-class EventEmitter extends CoreEmitter
+class EventEmitter
 {
+    /**
+     * @var array
+     */
+    protected $listeners = array();
 
     /**
      * Register a function with a hook. TODO support $accepted_args
@@ -17,7 +19,7 @@ class EventEmitter extends CoreEmitter
     public function on($hook, $function_to_add, $priority = 10)
     {
         if (function_exists('add_action')) {
-            \add_action($hook, $function_to_add, $priority);
+            add_action($hook, $function_to_add, $priority);
             return $this;
         }
 
@@ -25,15 +27,54 @@ class EventEmitter extends CoreEmitter
             throw new \InvalidArgumentException('The provided listener was not a valid callable.');
         }
 
-        if (!isset($this->listeners[$hook])) {
-            $this->listeners[$hook] = array();
-        }
-
-        $this->listeners[$hook][$priority] = $function_to_add;
+        $this->addListener($hook, $function_to_add, $priority);
         krsort($this->listeners[$hook]);
 
         return $this;
     }
+
+    /**
+     * Register a filter with a hook. TODO support $accepted args
+     *
+     * @param $hook
+     * @param $function_to_add
+     * @param $priority
+     * @return $this
+     */
+    public function filter($hook, $function_to_add, $priority = 10)
+    {
+        if (function_exists('add_filter')) {
+            add_filter($hook, $function_to_add, $priority);
+            return $this;
+        }
+
+        if (! function_exists('add_action')) {
+            $this->on($hook, $function_to_add, $priority);
+        }
+
+        return $this;
+    }
+
+    /**
+     * This function invokes all functions for a hook and transforms the given value(s)
+     *
+     * @param $hook
+     * @param $value
+     * @return $this|mixed
+     */
+    public function applyFilters($hook, $value /** ...args */)
+    {
+        $args = func_get_args();
+        $args = array_slice($args, 1);
+
+        if (function_exists('apply_filters')) {
+            call_user_func_array('apply_filters', $args);
+            return $this;
+        }
+
+        return $this->invokeListeners($hook, $args);
+    }
+
 
     /**
      * This function invokes all functions attached to action hook $tag
@@ -50,8 +91,58 @@ class EventEmitter extends CoreEmitter
             return $this;
         }
 
-        parent::emit($tag, $args);
+        $this->invokeListeners($tag, $arguments);
 
         return $this;
+    }
+
+    /**
+     * Return the listeners for a given hook
+     *
+     * @param $hook
+     * @return array
+     */
+    protected function listeners($hook)
+    {
+        return $this->listeners[$hook];
+    }
+
+    /**
+     * Add a prioritized listener
+     *
+     * @param $hook
+     * @param $function_to_add
+     * @param $priority
+     */
+    protected function addListener($hook, $function_to_add, $priority)
+    {
+        if (!isset($this->listeners[$hook])) {
+            $this->listeners[$hook] = array();
+        }
+
+        if (!isset($this->listeners[$hook][$priority])) {
+            $this->listeners[$hook][$priority] = array();
+        }
+
+        $this->listeners[$hook][$priority][] = $function_to_add;
+    }
+
+    /**
+     * Invoke all listeners for a given hook
+     *
+     * @param $listeners
+     * @param array $argument
+     */
+    protected function invokeListeners($hook, array $arguments)
+    {
+        $value = '';
+        $listeners = $this->listeners($hook);
+        foreach ($listeners as $key => $set) {
+            foreach ($set as $listener) {
+                $value = call_user_func_array($listener, $arguments);
+                $arguments[0] = $value;
+            }
+        }
+        return $value;
     }
 }

--- a/src/EventEmitterInterface.php
+++ b/src/EventEmitterInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace NetRivet\WordPress;
+
+interface EventEmitterInterface
+{
+    /**
+     * Register a function with a hook. TODO support $accepted_args
+     *
+     * @param $hook
+     * @param $function_to_add
+     * @param $int $priority
+     */
+    public function on($hook, $function_to_add, $priority = 10);
+
+    /**
+     * Register a filter with a hook. TODO support $accepted args
+     *
+     * @param $hook
+     * @param $function_to_add
+     * @param $priority
+     * @return $this
+     */
+    public function filter($hook, $function_to_add, $priority = 10);
+
+    /**
+     * This function invokes all functions for a hook and transforms the given value(s)
+     *
+     * @param $hook
+     * @param $value
+     * @return $this|mixed
+     */
+    public function applyFilters($hook, $value);
+
+    /**
+     * This function invokes all functions attached to action hook $tag
+     *
+     * @param $tag
+     */
+    public function emit($tag, array $arguments = array());
+}

--- a/test/EventEmitterTest.php
+++ b/test/EventEmitterTest.php
@@ -30,4 +30,19 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('early', $result);
     }
+
+    public function testFilters()
+    {
+        $this->emitter->filter('the_content', function ($content, $append) {
+            return $content . ' ' . $append;
+        });
+
+        $this->emitter->filter('the_content', function ($content) {
+            return $content . ' yolo';
+        });
+
+        $content = $this->emitter->applyFilters('the_content', 'ham', 'sandwich');
+
+        $this->assertEquals('ham sandwich yolo', $content);
+    }
 }


### PR DESCRIPTION
This PR removes evenement because it was too difficult to support priorities.

This also adds support for filters via two new methods:
- `filter`
- `applyFilters`

In addition - an interface for the `EventEmitter` is included if consuming libraries want the abstraction.

This will result in a 2.0 tag as it changes the API by removing evenement
