### PR TITLE
prevent php notices and warnings when applying filters with no listeners

### DIFF
--- a/src/EventEmitter.php
+++ b/src/EventEmitter.php
@@ -104,7 +104,7 @@ class EventEmitter implements EventEmitterInterface
      */
     protected function listeners($hook)
     {
-        return $this->listeners[$hook];
+        return isset($this->listeners[$hook]) ? $this->listeners[$hook] : array();
     }
 
     /**

--- a/test/EventEmitterTest.php
+++ b/test/EventEmitterTest.php
@@ -45,4 +45,9 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('ham sandwich yolo', $content);
     }
+
+    public function testPhpNoticesOrWarningsNotEmittedWhenApplyingFiltersToHookWithNoFilter()
+    {
+        $this->emitter->applyFilters('jim_jam', 'yolo neckbeard');
+    }
 }


### PR DESCRIPTION
It's very common within WordPress to have `apply_filters` called when no consuming code has added a filter.  When the same happens in a test environment with `EventEmitter::applyFilters` the fallback queue system triggers notices and warnings, which seem not desirable.
