### PR TITLE
return value from applyFilters when no filters added

### DIFF
--- a/src/EventEmitter.php
+++ b/src/EventEmitter.php
@@ -133,11 +133,13 @@ class EventEmitter implements EventEmitterInterface
      * @param string $hook
      * @param array $argument
      * @param string $type
+     * @return mixed
      */
     protected function invokeHook($hook, array $arguments, $type)
     {
-        $value = '';
         $listeners = $this->listeners($hook);
+
+        $value = isset($arguments[0]) ? $arguments[0] : '';
 
         foreach ($listeners as $key => $set) {
             $value = $this->invokeListeners($set, $arguments, $type);

--- a/test/EventEmitterTest.php
+++ b/test/EventEmitterTest.php
@@ -80,4 +80,13 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNotEmpty($test);
     }
+
+    public function testCallingApplyFiltersWithNoFiltersAddedReturnsValue()
+    {
+        $toFilter = 'foobar';
+
+        $filtered = $this->emitter->applyFilters('foo', $toFilter);
+
+        $this->assertSame($toFilter, $filtered);
+    }
 }


### PR DESCRIPTION
This is another layer of compatibility with the WordPress hook api.  If you call `apply_filters('foo', 'bar');` when no filters have been added with `add_filter()` then WordPress will return `'bar'`. `EventEmitter` was returning null.

Fix is pretty simple, initialize the return value of `invokeHook` to the var to be filtered, if present.
