### PR TITLE
add hasEventListener and hasFilter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.6"
+        "phpunit/phpunit": "^4.6",
+        "symfony/var-dumper": "~2.6.0"
     }
 }

--- a/src/EventEmitter.php
+++ b/src/EventEmitter.php
@@ -132,7 +132,48 @@ class EventEmitter implements EventEmitterInterface
             return call_user_func($wp_has_listener, $hook, $function_to_check);
         }
 
-        return (bool) $this->listeners($hook);
+        return $this->hasInternalListener($hook, $function_to_check);
+    }
+
+    /**
+     * Check if an internal listener exists for hook and optional function
+     *
+     * If the optional second $function_to_check arg is passed, check
+     * if that specific callable has been registered as a listener.
+     *
+     * @param  string  $hook
+     * @param  mixed $function_to_check
+     * @return boolean
+     */
+    protected function hasInternalListener($hook, $function_to_check)
+    {
+        $listeners = $this->listeners($hook);
+
+        if (!$listeners) {
+            return false;
+        }
+
+        if ($function_to_check === false) {
+            return true;
+        }
+
+        return $this->hasMatchingListener($listeners, $function_to_check);
+    }
+
+    /**
+     * Does a specific callable exist in an array of prioritized listeners
+     *
+     * @param  array    $listeners
+     * @param  callable $function_to_check
+     * @return boolean
+     */
+    protected function hasMatchingListener(array $listeners, $function_to_check)
+    {
+        $listeners = array_reduce($listeners, 'array_merge', array());
+
+        return (bool) array_filter($listeners, function ($listener) use ($function_to_check) {
+            return $listener == $function_to_check;
+        });
     }
 
     /**

--- a/src/EventEmitter.php
+++ b/src/EventEmitter.php
@@ -12,14 +12,14 @@ class EventEmitter implements EventEmitterInterface
     /**
      * {@inheritdoc}
      *
-     * @param $hook
+     * @param $event
      * @param $function_to_add
      * @param $int $priority
      */
-    public function on($hook, $function_to_add, $priority = 10)
+    public function on($event, $function_to_add, $priority = 10)
     {
         if (function_exists('add_action')) {
-            add_action($hook, $function_to_add, $priority);
+            add_action($event, $function_to_add, $priority);
             return $this;
         }
 
@@ -27,8 +27,8 @@ class EventEmitter implements EventEmitterInterface
             throw new \InvalidArgumentException('The provided listener was not a valid callable.');
         }
 
-        $this->addListener($hook, $function_to_add, $priority);
-        krsort($this->listeners[$hook]);
+        $this->addListener($event, $function_to_add, $priority);
+        krsort($this->listeners[$event]);
 
         return $this;
     }
@@ -36,33 +36,30 @@ class EventEmitter implements EventEmitterInterface
     /**
      * {@inheritdoc}
      *
-     * @param $hook
-     * @param $function_to_add
-     * @param $priority
+     * @param string $name
+     * @param mixed $function_to_add
+     * @param int $priority
      * @return $this
      */
-    public function filter($hook, $function_to_add, $priority = 10)
+    public function filter($name, $function_to_add, $priority = 10)
     {
         if (function_exists('add_filter')) {
-            add_filter($hook, $function_to_add, $priority);
+            add_filter($name, $function_to_add, $priority);
             return $this;
         }
 
-        if (! function_exists('add_action')) {
-            $this->on($hook, $function_to_add, $priority);
-        }
-
+        $this->on($name, $function_to_add, $priority);
         return $this;
     }
 
     /**
      * {@inheritdoc}
      *
-     * @param $hook
+     * @param $name
      * @param $value
      * @return $this|mixed
      */
-    public function applyFilters($hook, $value /** ...args */)
+    public function applyFilters($name, $value /** ...args */)
     {
         $args = func_get_args();
         $args = array_slice($args, 1);
@@ -72,7 +69,7 @@ class EventEmitter implements EventEmitterInterface
             return $this;
         }
 
-        return $this->invokeHook($hook, $args, 'filter');
+        return $this->invokeHook($name, $args, 'filter');
     }
 
 
@@ -81,7 +78,7 @@ class EventEmitter implements EventEmitterInterface
      *
      * @param $tag
      */
-    public function emit($tag /** ... args */)
+    public function emit($event /** ... args */)
     {
         $args = func_get_args();
         $rest = array_slice($args, 1);
@@ -91,9 +88,51 @@ class EventEmitter implements EventEmitterInterface
             return $this;
         }
 
-        $this->invokeHook($tag, $rest, 'action');
+        $this->invokeHook($event, $rest, 'action');
 
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @todo handle $function_to_check when using internal test listeners
+     */
+    public function hasEventListener($event, $function_to_check = false)
+    {
+        return $this->hasListener('action', $event, $function_to_check);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @todo handle $function_to_check when using internal test listeners
+     */
+    public function hasFilter($name, $function_to_check = false)
+    {
+        return $this->hasListener('filter', $name, $function_to_check);
+    }
+
+    /**
+     * Check if listener exists for type, hook, and function
+     *
+     * Delegates to WordPress `has_action` and `has_filter` when present,
+     * or falls back to internal listener queue for testing purposes
+     *
+     * @param  string  $type
+     * @param  string  $hook
+     * @param  mixed $function_to_check
+     * @return boolean
+     */
+    protected function hasListener($type, $hook, $function_to_check = false)
+    {
+        $wp_has_listener = 'has_' . $type;
+
+        if (function_exists($wp_has_listener)) {
+            return call_user_func($wp_has_listener, $hook, $function_to_check);
+        }
+
+        return (bool) $this->listeners($hook);
     }
 
     /**

--- a/src/EventEmitterInterface.php
+++ b/src/EventEmitterInterface.php
@@ -7,21 +7,21 @@ interface EventEmitterInterface
     /**
      * Register a function with a hook. TODO support $accepted_args
      *
-     * @param $hook
+     * @param $event
      * @param $function_to_add
      * @param $int $priority
      */
-    public function on($hook, $function_to_add, $priority = 10);
+    public function on($event, $function_to_add, $priority = 10);
 
     /**
      * Register a filter with a hook. TODO support $accepted args
      *
-     * @param $hook
+     * @param $name
      * @param $function_to_add
      * @param $priority
      * @return $this
      */
-    public function filter($hook, $function_to_add, $priority = 10);
+    public function filter($name, $function_to_add, $priority = 10);
 
     /**
      * This function invokes all functions for a hook and transforms the given value(s)
@@ -35,7 +35,31 @@ interface EventEmitterInterface
     /**
      * This function invokes all functions attached to action hook $tag
      *
-     * @param $tag
+     * @param string $event
      */
-    public function emit($tag /** ... args */);
+    public function emit($event /** ... args */);
+
+    /**
+     * Is an event listener registered for the given event
+     *
+     * Delegates to WordPress' `has_action` when present, or falls back
+     * to internal listener queue for testing purposes.
+     *
+     * @param  string $event
+     * @param  mixed  $function_to_check
+     * @return boolean
+     */
+    public function hasEventListener($event, $function_to_check = false);
+
+    /**
+     * Has a filter function been registered for a given filter name
+     *
+     * Delegates to WordPress' `has_filter` when present, or falls back
+     * to internal listener queue for testing purposes.
+     *
+     * @param  string $name
+     * @param  mixed  $function_to_check
+     * @return boolean
+     */
+    public function hasFilter($name, $function_to_check = false);
 }

--- a/test/EventEmitterTest.php
+++ b/test/EventEmitterTest.php
@@ -121,4 +121,76 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($hasFilter);
     }
+
+    public function testHasEventListenerReturnsFalseWhenStringFunctionToCheckDoesNotMatch()
+    {
+        $this->emitter->on('foo', 'phpinfo');
+
+        $hasListener = $this->emitter->hasEventListener('foo', 'some_other_func');
+
+        $this->assertFalse($hasListener);
+    }
+
+    public function testHasEventListenerReturnsTrueWhenStringFunctionToCheckMatches()
+    {
+        $this->emitter->on('foo', 'phpinfo');
+
+        $hasListener = $this->emitter->hasEventListener('foo', 'phpinfo');
+
+        $this->assertTrue($hasListener);
+    }
+
+    public function testHasEventListenerReturnsTrueWhenClosuresSame()
+    {
+        $saySomething = function () {
+            echo 'something';
+        };
+
+        $this->emitter->on('foo', $saySomething);
+
+        $hasListener = $this->emitter->hasEventListener('foo', $saySomething);
+
+        $this->assertTrue($hasListener);
+    }
+
+    public function testHasEventListenerReturnsFalseWhenComparingDifferentClosures()
+    {
+        $this->emitter->on('foo', function () {
+            echo 'foo';
+        });
+
+        $hasListener = $this->emitter->hasEventListener('foo', function () {
+            echo 'foo';
+        });
+
+        $this->assertFalse($hasListener);
+    }
+
+    public function testHasEventListenerReturnsTrueWhenPassedSameArrayCallable()
+    {
+        $this->emitter->on('foo', array($this, 'listener1'));
+
+        $hasListener = $this->emitter->hasEventListener('foo', array($this, 'listener1'));
+
+        $this->assertTrue($hasListener);
+    }
+
+    public function testHasEventListenerReturnsFalseWhenPassedDifferentArrayCallable()
+    {
+        $this->emitter->on('foo', array($this, 'listener1'));
+
+        $hasListener = $this->emitter->hasEventListener('foo', array($this, 'listener2'));
+
+        $this->assertFalse($hasListener);
+    }
+
+    public function listener1()
+    {
+        // do a thing
+    }
+
+    public function listener2()
+    {
+        // do another thing
+    }
 }

--- a/test/EventEmitterTest.php
+++ b/test/EventEmitterTest.php
@@ -89,4 +89,36 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($toFilter, $filtered);
     }
+
+    public function testHasEventListenerReturnsFalseWhenNoListenerAdded()
+    {
+        $hasListener = $this->emitter->hasEventListener('foo');
+
+        $this->assertFalse($hasListener);
+    }
+
+    public function testHasEventListenerReturnsTrueWhenListenerAdded()
+    {
+        $this->emitter->on('foo', 'phpinfo');
+
+        $hasListener = $this->emitter->hasEventListener('foo');
+
+        $this->assertTrue($hasListener);
+    }
+
+    public function testHasFilterReturnsFalseWhenNoFilterAdded()
+    {
+        $hasFilter = $this->emitter->hasFilter('foo');
+
+        $this->assertFalse($hasFilter);
+    }
+
+    public function testHasFilterReturnsTrueWhenFilterAdded()
+    {
+        $this->emitter->filter('foo', 'strtoupper');
+
+        $hasFilter = $this->emitter->hasFilter('foo');
+
+        $this->assertTrue($hasFilter);
+    }
 }


### PR DESCRIPTION
This PR adds analogs for `has_action` and  `has_filter` named `EventEmitter::hasEventListener` and `EventEmitter::hasFilter`, respectively.  I'm open to naming input on both, especially `hasEventListener`.

WordPress has a way of allowing you to check if a specific function is registered by passing it as an optional second arg. I support this by passing it through when the WordPress global function is present, but left implementing this kind of check as a todo for the internal testing listener queue.

Also, I renamed some internal variables, straying from WordPress naming convention of `$tag` for action and filter identifiers.  I felt like one of the benefits of this interface is that we can use the more familiar and clear `$this->on()` and `$this->emit()` methods, and it makes sense that those would both take an `$event` var instead of `$tag`.  So basically, my thought was to hide the WordPress weirdness behind a prettier façade. But, with this, I'm open to input as well if it seems that consistency with WordPress is more important.
