### PR TITLE
return result of calling WordPress apply_filters

### DIFF
--- a/src/EventEmitter.php
+++ b/src/EventEmitter.php
@@ -62,14 +62,13 @@ class EventEmitter implements EventEmitterInterface
     public function applyFilters($name, $value /** ...args */)
     {
         $args = func_get_args();
-        $args = array_slice($args, 1);
+        $rest = array_slice($args, 1);
 
         if (function_exists('apply_filters')) {
-            call_user_func_array('apply_filters', $args);
-            return $this;
+            return call_user_func_array('apply_filters', $args);
         }
 
-        return $this->invokeHook($name, $args, 'filter');
+        return $this->invokeHook($name, $rest, 'filter');
     }
 
 

--- a/test/EventEmitterTest.php
+++ b/test/EventEmitterTest.php
@@ -184,6 +184,30 @@ class EventEmitterTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($hasListener);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
+    public function testWhenWordpressApplyFiltersExistsReturnsResultOfCallingThatFunction()
+    {
+        eval('function apply_filters() { return "foobar"; }');
+
+        $filtered = $this->emitter->applyFilters('some_filter', 'jimjam');
+
+        $this->assertSame('foobar', $filtered);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testCorrectArgsPassedToWordpressFunctionWhenPresent()
+    {
+        eval('function apply_filters() { return func_get_args(); }');
+
+        $filtered = $this->emitter->applyFilters('foo', 'bar');
+
+        $this->assertSame(array('foo', 'bar'), $filtered);
+    }
+
     public function listener1()
     {
         // do a thing


### PR DESCRIPTION
When testing some middleware integration in the WordPress environment, I ran in to some unexpected errors. It turns out the `EventEmitter::applyFilters` method had some flaws in it's implementation when the global WordPress `apply_filters` function exists:
- `apply_filters` was not getting passed the correct arguments
- `EventEmitter::applyFilters` was not returning the result of calling `apply_filters`

This PR fixes both of those issues.  I thought about not writing tests for them, since they require the presence of the global functions - but then I thought I might leverage PHPUnit's `@runInSeparateProcess` annotation to actually trap the bug and test it.  If this is deemed smelly or there's a better way I'm open to removing or refactoring these tests.
